### PR TITLE
feat: scaffold project structure for civitcli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Civitai CLI
+
+Thank you for your interest in improving `civitcli`! This document outlines the basic workflow for contributing to the
+project during the early milestones.
+
+## Getting Started
+
+1. Fork and clone the repository.
+2. Create a feature branch from the latest `main` branch.
+3. Install development dependencies:
+
+   ```bash
+   pip install -e .[dev]
+   ```
+
+4. Run the test suite to verify your environment:
+
+   ```bash
+   pytest
+   ```
+
+## Development Guidelines
+
+- Follow the milestones defined in `docs/implementation-plan.md` to keep work incremental.
+- Write tests for new functionality and ensure `pytest` passes before opening a pull request.
+- Use descriptive commit messages and reference the milestone you are addressing when possible.
+- Keep the CLI entry point (`civitcli`) stable to preserve compatibility with pipx installations.
+
+## Pull Request Process
+
+1. Ensure your branch is up to date with `main`.
+2. Provide a clear summary of your changes and any testing performed.
+3. Request a review from a maintainer.
+4. Address feedback promptly and keep the conversation in the pull request.
+
+By contributing you agree to license your work under the repository's MIT License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Civitai CLI (MVP)
+
+`civitcli` is a command-line utility that helps you manage assets from [Civitai](https://civitai.com) and generate
+`stable-diffusion.cpp` commands from the platform's metadata blocks. The project is in active development, and this
+milestone provides the initial package scaffolding.
+
+## Installation
+
+The CLI is designed for use with [pipx](https://pipx.pypa.io/). To install directly from a git checkout:
+
+```bash
+pipx install git+https://github.com/your-org/civitcli.git
+```
+
+During development you can run the tool in-place:
+
+```bash
+pipx run --spec . civitcli --help
+```
+
+## Usage
+
+This milestone focuses on the CLI interface scaffolding. Run the command below to explore the available options:
+
+```bash
+civitcli --help
+```
+
+Future milestones will enable downloading Civitai resources and rendering `stable-diffusion.cpp` commands.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.

--- a/civitcli/__init__.py
+++ b/civitcli/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for the Civitai CLI."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.0.1"

--- a/civitcli/__main__.py
+++ b/civitcli/__main__.py
@@ -1,0 +1,10 @@
+"""Module executed when running ``python -m civitcli``."""
+
+from __future__ import annotations
+
+from .cli import main
+
+__all__ = ["main"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/civitcli/cli.py
+++ b/civitcli/cli.py
@@ -1,0 +1,77 @@
+"""Command-line interface for :mod:`civitcli`."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Optional, Sequence
+
+from . import __version__
+
+_LOG_FORMAT = "%(levelname)s: %(message)s"
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the argument parser used by the CLI."""
+
+    parser = argparse.ArgumentParser(
+        prog="civitcli",
+        description="Tools for downloading Civitai resources and rendering stable-diffusion.cpp commands.",
+    )
+    parser.add_argument(
+        "--download",
+        metavar="URL",
+        help="Download a resource from the provided Civitai URL (future milestone).",
+    )
+    parser.add_argument(
+        "--render",
+        action="store_true",
+        help="Parse generation metadata and output a stable-diffusion.cpp command (future milestone).",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity (can be supplied multiple times).",
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    return parser
+
+
+def _configure_logging(verbosity: int) -> None:
+    """Initialise logging according to the requested verbosity level."""
+
+    if verbosity >= 2:
+        level = logging.DEBUG
+    elif verbosity == 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+
+    logging.basicConfig(level=level, format=_LOG_FORMAT)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Entry point for the console script."""
+
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    _configure_logging(args.verbose)
+
+    if args.download:
+        logging.warning("Download functionality is not yet implemented in this milestone.")
+    if args.render:
+        logging.warning("Render functionality is not yet implemented in this milestone.")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - handled by __main__.py
+    raise SystemExit(main())

--- a/civitcli/config.py
+++ b/civitcli/config.py
@@ -1,0 +1,30 @@
+"""Configuration helpers for :mod:`civitcli`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+# Default paths sourced from the MVP PRD.
+DEFAULT_MODELS_DIR = Path("/opt/md2/backup/civitai/models")
+DEFAULT_LORAS_DIR = DEFAULT_MODELS_DIR / "loras"
+DEFAULT_EMBEDDINGS_DIR = DEFAULT_MODELS_DIR / "embeddings"
+
+
+@dataclass(frozen=True)
+class DownloadPaths:
+    """Container for download target directories."""
+
+    checkpoints: Path = DEFAULT_MODELS_DIR
+    loras: Path = DEFAULT_LORAS_DIR
+    embeddings: Path = DEFAULT_EMBEDDINGS_DIR
+
+
+def load_download_paths() -> DownloadPaths:
+    """Return the download paths using default configuration.
+
+    Future milestones will extend this function to read from environment
+    variables and configuration files.
+    """
+
+    return DownloadPaths()

--- a/civitcli/downloader.py
+++ b/civitcli/downloader.py
@@ -1,0 +1,21 @@
+"""Download helpers for Civitai resources."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+class DownloadError(RuntimeError):
+    """Raised when a download fails."""
+
+
+def download_resource(url: str, *, session: Optional[object] = None) -> Path:  # pragma: no cover - stub
+    """Download a resource from ``url``.
+
+    This stub will be implemented in Milestone 1. It currently raises
+    :class:`NotImplementedError` to signal that the functionality is not yet
+    available.
+    """
+
+    raise NotImplementedError("Download functionality will be delivered in Milestone 1.")

--- a/civitcli/renderer/__init__.py
+++ b/civitcli/renderer/__init__.py
@@ -1,0 +1,3 @@
+"""Rendering helpers for generating stable-diffusion.cpp commands."""
+
+__all__: list[str] = []

--- a/civitcli/renderer/command_builder.py
+++ b/civitcli/renderer/command_builder.py
@@ -1,0 +1,12 @@
+"""Placeholder for stable-diffusion.cpp command construction."""
+
+from __future__ import annotations
+
+
+def build_command(parsed_data, *, verbose: bool = False):  # pragma: no cover - stub
+    """Build a command invocation from parsed metadata.
+
+    Implementation will arrive in Milestone 3.
+    """
+
+    raise NotImplementedError("Command building will be delivered in Milestone 3.")

--- a/civitcli/renderer/parser.py
+++ b/civitcli/renderer/parser.py
@@ -1,0 +1,12 @@
+"""Placeholder for generation data parsing logic."""
+
+from __future__ import annotations
+
+
+def parse_generation_data(raw: str):  # pragma: no cover - stub
+    """Parse generation metadata from ``raw``.
+
+    Implementation will arrive in Milestone 2.
+    """
+
+    raise NotImplementedError("Generation data parsing will be delivered in Milestone 2.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "civitcli"
+version = "0.0.1"
+description = "Command-line tools for working with Civitai resources"
+readme = "README.md"
+authors = [{name = "Civitai CLI Team"}]
+license = {text = "MIT"}
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7.4"]
+
+[project.scripts]
+civitcli = "civitcli.__main__:main"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["civitcli"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+"""Smoke tests for the civitcli command-line interface."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_cli_help() -> None:
+    """The CLI should respond to ``--help`` without error."""
+
+    result = subprocess.run(
+        [sys.executable, "-m", "civitcli", "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- add initial pyproject configuration with hatchling build backend and pytest settings
- scaffold the civitcli package with CLI entry point, configuration defaults, and placeholder modules
- document installation/contribution basics and add a CLI smoke test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dcbe907240832187a51bce1797a20b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initial package scaffolding adding a `civitcli` CLI, config defaults, downloader/renderer stubs, packaging with Hatch, docs, and a CLI smoke test.
> 
> - **CLI/Core**:
>   - Add `civitcli/cli.py` with `--download`, `--render`, verbosity, and version flags; logging setup.
>   - Entry points via `civitcli/__main__.py` and `pyproject.toml` `project.scripts`.
>   - Define `__version__` in `civitcli/__init__.py`.
> - **Config**:
>   - Introduce `civitcli/config.py` with default model paths and `DownloadPaths` + `load_download_paths()`.
> - **Placeholders**:
>   - `civitcli/downloader.py`: `download_resource` stub and `DownloadError`.
>   - `civitcli/renderer/` with `parser.py` and `command_builder.py` stubs.
> - **Packaging/Build**:
>   - Add `pyproject.toml` (Hatchling, Python>=3.10, optional `dev` deps, pytest settings, wheel packages).
> - **Docs**:
>   - Add `README.md` (install/usage) and `CONTRIBUTING.md`.
> - **Tests**:
>   - Add `tests/test_cli.py` smoke test for `python -m civitcli --help`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02d43facbc8a827e38afa4c914f6cf4d8b8dcf2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->